### PR TITLE
Update heap setting in memory config example

### DIFF
--- a/memory-sample/README.md
+++ b/memory-sample/README.md
@@ -29,7 +29,7 @@ The application will print how much memory it is using. You will notice that Doc
 To fix this, run the application like this:
 
 ```
-> docker run --memory 100M -e JAVA_OPTIONS='-Xmx100m' memory-sample
+> docker run --memory 100M -e JAVA_OPTIONS='-Xmx64m' memory-sample
 ```
 
 


### PR DESCRIPTION
The mx setting for the JVM defines how large the java heap may get. In addition to the java heap, the JVM uses additional memory, for example for control structures for the heap, to allocate generated code in and for a few other things. How much depends mostly on the application and how it behaves, but also on the platform it is run on. So to show this, it would be better to have different mx value to docker memory value.

Otherwise it will most likely fail just as it does when mx isn't set.

Cheers,
Stefan