### PR TITLE
Add -XX:MaxRAMFraction=1 JVM argument to documentation

### DIFF
--- a/memory-sample/README.md
+++ b/memory-sample/README.md
@@ -36,7 +36,7 @@ To fix this, run the application like this:
 As of Java 8u131 there is now an experimental VM option so the JVM is aware of the --memory switch used by Docker:
 
 ```
-> docker run --memory 100M -e JAVA_OPTIONS='-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap' memory-sample
+> docker run --memory 100M -e JAVA_OPTIONS='-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1' memory-sample
 ```
 
 The JAVA_OPTION variable is defined in our pom.xml, when the image is created.


### PR DESCRIPTION
See:
https://blog.csanchez.org/2017/05/31/running-a-jvm-in-a-container-without-getting-killed/